### PR TITLE
Remove configuração do active_support e action_mailer

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,20 +29,6 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
-  config.action_mailer.perform_caching = false
-
-  # Print deprecation notices to the Rails logger.
-  config.active_support.deprecation = :log
-
-  # Raise exceptions for disallowed deprecations.
-  config.active_support.disallowed_deprecation = :raise
-
-  # Tell Active Support which deprecation messages to disallow.
-  config.active_support.disallowed_deprecation_warnings = []
-
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,8 +54,6 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "flash_parsing_production"
 
-  config.action_mailer.perform_caching = false
-
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
@@ -63,15 +61,6 @@ Rails.application.configure do
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
-
-  # Send deprecation notices to registered listeners.
-  config.active_support.deprecation = :notify
-
-  # Log disallowed deprecations.
-  config.active_support.disallowed_deprecation = :log
-
-  # Tell Active Support which deprecation messages to disallow.
-  config.active_support.disallowed_deprecation_warnings = []
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,7 +11,6 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   config.cache_classes = false
-  config.action_view.cache_template_loading = true
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
@@ -29,27 +28,8 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
-  # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
-
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
-
-  config.action_mailer.perform_caching = false
-
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
-
-  # Print deprecation notices to the stderr.
-  config.active_support.deprecation = :stderr
-
-  # Raise exceptions for disallowed deprecations.
-  config.active_support.disallowed_deprecation = :raise
-
-  # Tell Active Support which deprecation messages to disallow.
-  config.active_support.disallowed_deprecation_warnings = []
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true


### PR DESCRIPTION
Issue: #9 

Foi feito a remoção das configurações do active_support e action_mailer pois não serão usados no projeto.

## Pre-launch Checklist

- [x] Eu segui a [convensão do Rails](https://rubyonrails.org/doctrine/) sobre boas práticas de código;
- [x] Eu listei pelo menos um issue relacionado à este PR;
- [ ] Eu adicionei novos testes para cobrir as mudanças que eu fiz neste PR, ou este PR é uma exceção;
- [ ] Eu atualizei/adicionei comentários relevantes nas modificações efetuadas (caso necessário);
- [ ] Todos os testes previamente existentes e os novos criados por mim estão finalizando com sucesso;
